### PR TITLE
Add Apple II-specific build logic.

### DIFF
--- a/iss-tracker/atari/makefiles/custom-apple2.mk
+++ b/iss-tracker/atari/makefiles/custom-apple2.mk
@@ -1,0 +1,38 @@
+# COMPILE FLAGS
+
+# reserved memory for graphics
+# LDFLAGS += -Wl -D,__RESERVED_MEMORY__=0x2000
+
+#LDFLAGS += --start-addr 0x4400
+#LDFLAGS += -C cfg/atari.cfg
+
+################################################################
+# DISK creation
+
+SUFFIX =
+DISK_TASKS += .po
+AUTOBOOT := -l
+APPLE_TOOLS_DIR := ../apple-tools
+
+.po:
+	$(call RMFILES,$(DIST_DIR)/$(APP_NAME)*.po)
+	cp $(DIST_DIR)/$(PROGRAM_TGT)$(SUFFIX) $(DIST_DIR)/$(PROGRAM)$(SUFFIX)
+	$(APPLE_TOOLS_DIR)/mk-bitsy.sh $(DIST_DIR)/$(PROGRAM).po $(PROGRAM)$(SUFFIX)
+	$(APPLE_TOOLS_DIR)/add-file.sh $(AUTOBOOT) $(DIST_DIR)/$(PROGRAM).po $(DIST_DIR)/$(PROGRAM)$(SUFFIX) $(PROGRAM)
+
+# Applewin debug script
+.gendebug: $(PROGRAM_TGT)
+	@if [ -f "build/$(PROGRAM_TGT).lbl" ]; then \
+		echo "Generating debug.scr script for AppleWin"; \
+		echo 'echo "Loading symbols"' > build/debug.scr; \
+		awk '{printf("sym %s = %s\n", substr($$3, 2), $$2)}' < build/$(PROGRAM_TGT).lbl >> build/debug.scr; \
+		echo 'bpx _main' >> build/debug.scr; \
+		echo 'bpx _debug' >> build/debug.scr; \
+		echo 'bpx _network_open' >> build/debug.scr; \
+		echo 'bpx _sp_init' >> build/debug.scr; \
+	fi
+
+ALL_TASKS += .gendebug
+
+################################################################
+# TESTING / EMULATOR


### PR DESCRIPTION
If we consider iss-tracker/atari/makefiles as "template" to copy from for new programs, then it seems desirable to have the Apple II-specific code in place although it is - of course - not actually used here. The Apple II-specific code stems again from fujinet-lib-examples/makefiles.